### PR TITLE
[Enhancement] モックプレビューのボディバックグラウンドとボディコンテキストメニューを作成する

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import "./App.css";
 import { SidebarInset, SidebarProvider } from "./components/ui/sidebar";
 import { Sidebar } from "./layouts/sidebar";
 import Header from "./layouts/header";
+import Body from "./layouts/body";
 
 function App() {
   return (
@@ -17,6 +18,7 @@ function App() {
         />
         <SidebarInset>
           <Header />
+          <Body />
         </SidebarInset>
       </SidebarProvider>
     </>

--- a/src/layouts/body.tsx
+++ b/src/layouts/body.tsx
@@ -1,0 +1,19 @@
+import {
+  Background,
+  Controls,
+  ReactFlow,
+  ReactFlowProvider,
+} from "@xyflow/react";
+import "@xyflow/react/dist/style.css";
+
+export default function Body() {
+  return (
+    <>
+      <ReactFlowProvider>
+        <ReactFlow nodes={[]} edges={[]} />
+        <Background gap={20} size={1} />
+        <Controls className="bg-white border border-gray-200 rounded-lg shadow-sm" />
+      </ReactFlowProvider>
+    </>
+  );
+}

--- a/src/layouts/body.tsx
+++ b/src/layouts/body.tsx
@@ -15,6 +15,15 @@ import {
 import "@xyflow/react/dist/style.css";
 import { useState, type MouseEvent } from "react";
 
+/**
+ * ボディ
+ * @param props.initialContextMenuState - ボディコンテキストメニューの初期状態(主にテスト時に使用)
+ * @param props.onClickCreateUserPrompt - ボディコンテキストメニューのユーザープロンプト作成ボタンのハンドラー
+ * @param props.onClickCreateSystemPrompt - ボディコンテキストメニューのシステムプロンプト作成ボタンのハンドラー
+ * @param props.onClickUndo - ボディコンテキストメニューのUndoボタンのハンドラー
+ * @param props.onClickRedo - ボディコンテキストメニューのRedoボタンのハンドラー
+ * @param props.onClickPaste - ボディコンテキストメニューのペーストボタンのハンドラー
+ */
 interface BodyProps {
   // NOTE(#12): Storybook上での左クリックが`render()`した要素に届いていなかったので、
   // Storybookでは最初からボディコンテキストメニューを開いておく。

--- a/src/layouts/body.tsx
+++ b/src/layouts/body.tsx
@@ -1,19 +1,131 @@
 import {
+  ContextMenu,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuSubMenu,
+  ContextMenuSubMenuRoot,
+  ContextMenuSubMenuTrigger,
+} from "@/components/context-menu";
+import {
   Background,
   Controls,
   ReactFlow,
   ReactFlowProvider,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
+import { useState } from "react";
 
-export default function Body() {
+interface BodyProps {
+  onClickCreateUserPrompt?: () => void;
+  onClickCreateSystemPrompt?: () => void;
+  onClickUndo?: () => void;
+  onClickRedo?: () => void;
+  onClickPaste?: () => void;
+}
+
+type ContextMenuState =
+  | {
+      status: "open";
+      position: { x: number; y: number };
+    }
+  | {
+      status: "close";
+    };
+
+export default function Body({
+  onClickCreateUserPrompt,
+  onClickCreateSystemPrompt,
+  onClickUndo,
+  onClickRedo,
+  onClickPaste,
+}: BodyProps) {
+  const [contextMenuState, setContextMenuState] = useState<ContextMenuState>({
+    status: "close",
+  });
+
+  const onPaneContextMenu = ({
+    clientX,
+    clientY,
+  }: {
+    clientX: number;
+    clientY: number;
+  }) => {
+    setContextMenuState({
+      status: "open",
+      position: { x: clientX, y: clientY },
+    });
+  };
+  const onPaneClick = () => {
+    setContextMenuState({ status: "close" });
+  };
+
   return (
     <>
+      {contextMenuState.status === "open" && (
+        <BodyContextMenu
+          screenPosition={contextMenuState.position}
+          onClickCreateUserPrompt={onClickCreateUserPrompt}
+          onClickCreateSystemPrompt={onClickCreateSystemPrompt}
+          onClickUndo={onClickUndo}
+          onClickRedo={onClickRedo}
+          onClickPaste={onClickPaste}
+        />
+      )}
       <ReactFlowProvider>
-        <ReactFlow nodes={[]} edges={[]} />
+        <ReactFlow
+          nodes={[]}
+          edges={[]}
+          onPaneContextMenu={(e) => {
+            e.preventDefault();
+            onPaneContextMenu({
+              clientX: e.clientX,
+              clientY: e.clientY,
+            });
+          }}
+          onPaneClick={onPaneClick}
+        />
         <Background gap={20} size={1} />
         <Controls className="bg-white border border-gray-200 rounded-lg shadow-sm" />
       </ReactFlowProvider>
     </>
+  );
+}
+
+interface BodyContextMenuProps {
+  screenPosition: { x: number; y: number };
+  onClickCreateUserPrompt?: () => void;
+  onClickCreateSystemPrompt?: () => void;
+  onClickUndo?: () => void;
+  onClickRedo?: () => void;
+  onClickPaste?: () => void;
+}
+
+function BodyContextMenu({
+  screenPosition,
+  onClickCreateUserPrompt,
+  onClickCreateSystemPrompt,
+  onClickUndo,
+  onClickRedo,
+  onClickPaste,
+}: BodyContextMenuProps) {
+  return (
+    <ContextMenu screenPosition={screenPosition}>
+      <ContextMenuSubMenuRoot>
+        <ContextMenuSubMenuTrigger>作成</ContextMenuSubMenuTrigger>
+        <ContextMenuSubMenu>
+          <ContextMenuItem onClick={onClickCreateUserPrompt}>
+            ユーザープロンプト
+          </ContextMenuItem>
+          <ContextMenuItem onClick={onClickCreateSystemPrompt}>
+            システムプロンプト
+          </ContextMenuItem>
+        </ContextMenuSubMenu>
+      </ContextMenuSubMenuRoot>
+      <ContextMenuSeparator />
+      <ContextMenuItem onClick={onClickUndo}>Undo</ContextMenuItem>
+      <ContextMenuItem onClick={onClickRedo}>Redo</ContextMenuItem>
+      <ContextMenuSeparator />
+      <ContextMenuItem onClick={onClickPaste}>ペースト</ContextMenuItem>
+    </ContextMenu>
   );
 }

--- a/src/layouts/body.tsx
+++ b/src/layouts/body.tsx
@@ -16,6 +16,9 @@ import "@xyflow/react/dist/style.css";
 import { useState } from "react";
 
 interface BodyProps {
+  // NOTE(#12): Storybook上での左クリックが`render()`した要素に届いていなかったので、
+  // Storybookでは最初からボディコンテキストメニューを開いておく。
+  initialContextMenuState?: ContextMenuState;
   onClickCreateUserPrompt?: () => void;
   onClickCreateSystemPrompt?: () => void;
   onClickUndo?: () => void;
@@ -33,15 +36,16 @@ type ContextMenuState =
     };
 
 export default function Body({
+  initialContextMenuState,
   onClickCreateUserPrompt,
   onClickCreateSystemPrompt,
   onClickUndo,
   onClickRedo,
   onClickPaste,
 }: BodyProps) {
-  const [contextMenuState, setContextMenuState] = useState<ContextMenuState>({
-    status: "close",
-  });
+  const [contextMenuState, setContextMenuState] = useState<ContextMenuState>(
+    initialContextMenuState ?? { status: "close" },
+  );
 
   const onPaneContextMenu = ({
     clientX,

--- a/src/layouts/body.tsx
+++ b/src/layouts/body.tsx
@@ -73,6 +73,7 @@ export default function Body({
           onClickUndo={onClickUndo}
           onClickRedo={onClickRedo}
           onClickPaste={onClickPaste}
+          closeContextMenu={() => setContextMenuState({ status: "close" })}
         />
       )}
       <ReactFlowProvider>
@@ -102,6 +103,7 @@ interface BodyContextMenuProps {
   onClickUndo?: () => void;
   onClickRedo?: () => void;
   onClickPaste?: () => void;
+  closeContextMenu: () => void;
 }
 
 function BodyContextMenu({
@@ -111,11 +113,13 @@ function BodyContextMenu({
   onClickUndo,
   onClickRedo,
   onClickPaste,
+  closeContextMenu,
 }: BodyContextMenuProps) {
   const stopPropagationAndInvoke = (handler?: () => void) => {
     return (e: MouseEvent) => {
       e.stopPropagation();
       handler?.();
+      closeContextMenu();
     };
   };
 

--- a/src/layouts/body.tsx
+++ b/src/layouts/body.tsx
@@ -13,7 +13,7 @@ import {
   ReactFlowProvider,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
-import { useState } from "react";
+import { useState, type MouseEvent } from "react";
 
 interface BodyProps {
   // NOTE(#12): Storybook上での左クリックが`render()`した要素に届いていなかったので、
@@ -112,24 +112,41 @@ function BodyContextMenu({
   onClickRedo,
   onClickPaste,
 }: BodyContextMenuProps) {
+  const stopPropagationAndInvoke = (handler?: () => void) => {
+    return (e: MouseEvent) => {
+      e.stopPropagation();
+      handler?.();
+    };
+  };
+
   return (
     <ContextMenu screenPosition={screenPosition}>
       <ContextMenuSubMenuRoot>
         <ContextMenuSubMenuTrigger>作成</ContextMenuSubMenuTrigger>
         <ContextMenuSubMenu>
-          <ContextMenuItem onClick={onClickCreateUserPrompt}>
+          <ContextMenuItem
+            onClick={stopPropagationAndInvoke(onClickCreateUserPrompt)}
+          >
             ユーザープロンプト
           </ContextMenuItem>
-          <ContextMenuItem onClick={onClickCreateSystemPrompt}>
+          <ContextMenuItem
+            onClick={stopPropagationAndInvoke(onClickCreateSystemPrompt)}
+          >
             システムプロンプト
           </ContextMenuItem>
         </ContextMenuSubMenu>
       </ContextMenuSubMenuRoot>
       <ContextMenuSeparator />
-      <ContextMenuItem onClick={onClickUndo}>Undo</ContextMenuItem>
-      <ContextMenuItem onClick={onClickRedo}>Redo</ContextMenuItem>
+      <ContextMenuItem onClick={stopPropagationAndInvoke(onClickUndo)}>
+        Undo
+      </ContextMenuItem>
+      <ContextMenuItem onClick={stopPropagationAndInvoke(onClickRedo)}>
+        Redo
+      </ContextMenuItem>
       <ContextMenuSeparator />
-      <ContextMenuItem onClick={onClickPaste}>ペースト</ContextMenuItem>
+      <ContextMenuItem onClick={stopPropagationAndInvoke(onClickPaste)}>
+        ペースト
+      </ContextMenuItem>
     </ContextMenu>
   );
 }

--- a/src/stories/layouts/body-test.stories.tsx
+++ b/src/stories/layouts/body-test.stories.tsx
@@ -47,17 +47,13 @@ export const BodyContextMenuItemsInvokeHandlers: Story = {
     datas.containerOnclickSpy.mockClear();
 
     // Act
-    const createButton = canvas.queryByText("作成");
-    if (!createButton) {
-      throw new Error("作成ボタンが見つかりません");
-    }
-    await user.hover(createButton);
+    await user.hover(canvas.getByText("作成"));
     const createUserPromptButton = canvas.getByText("ユーザープロンプト");
     await user.click(createUserPromptButton);
 
     // Assert
     await expect(datas.createUserPromptHandlerSpy).toHaveBeenCalled();
     await expect(datas.containerOnclickSpy).not.toHaveBeenCalled();
-    await expect(canvas.getByText("作成")).not.toBeInTheDocument();
+    await expect(canvas.queryByText("作成")).not.toBeInTheDocument();
   },
 };

--- a/src/stories/layouts/body-test.stories.tsx
+++ b/src/stories/layouts/body-test.stories.tsx
@@ -1,0 +1,63 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import Body from "@/layouts/body";
+import { expect, fn, userEvent, within } from "@storybook/test";
+
+const meta: Meta<typeof Body> = {
+  title: "Layouts/Body/Test",
+  component: Body,
+  parameters: {
+    layout: "fullscreen",
+  },
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const BodyContextMenuItemsInvokeHandlersDatas = {
+  containerOnclickSpy: fn(),
+  createUserPromptHandlerSpy: fn(),
+};
+
+export const BodyContextMenuItemsInvokeHandlers: Story = {
+  render: () => {
+    const datas = BodyContextMenuItemsInvokeHandlersDatas;
+    return (
+      <div
+        onClick={datas.containerOnclickSpy}
+        onKeyDown={datas.containerOnclickSpy}
+      >
+        <Body
+          initialContextMenuState={{
+            status: "open",
+            position: { x: 100, y: 100 },
+          }}
+          onClickCreateUserPrompt={datas.createUserPromptHandlerSpy}
+        />
+      </div>
+    );
+  },
+  play: async ({ canvasElement }) => {
+    // ボディコンテキストメニューの各ボタンをクリックすると、ハンドラーが呼ばれメニューが閉じる。
+    // 後ろの要素のハンドラーは呼び出されない。
+    // Arrange
+    const user = await userEvent.setup();
+    const canvas = within(canvasElement);
+    const datas = BodyContextMenuItemsInvokeHandlersDatas;
+    datas.containerOnclickSpy.mockClear();
+
+    // Act
+    const createButton = canvas.queryByText("作成");
+    if (!createButton) {
+      throw new Error("作成ボタンが見つかりません");
+    }
+    await user.hover(createButton);
+    const createUserPromptButton = canvas.getByText("ユーザープロンプト");
+    await user.click(createUserPromptButton);
+
+    // Assert
+    await expect(datas.createUserPromptHandlerSpy).toHaveBeenCalled();
+    await expect(datas.containerOnclickSpy).not.toHaveBeenCalled();
+    await expect(canvas.getByText("作成")).not.toBeInTheDocument();
+  },
+};

--- a/src/stories/layouts/body.stories.tsx
+++ b/src/stories/layouts/body.stories.tsx
@@ -1,0 +1,33 @@
+import Body from "@/layouts/body";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { action } from "storybook/actions";
+
+const meta: Meta<typeof Body> = {
+  title: "Layouts/Body",
+  component: Body,
+  parameters: {
+    layout: "fullscreen",
+  },
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => {
+    return (
+      <Body
+        initialContextMenuState={{
+          status: "open",
+          position: { x: 100, y: 100 },
+        }}
+        onClickCreateUserPrompt={action("onClickCreateUserPrompt")}
+        onClickCreateSystemPrompt={action("onClickCreateSystemPrompt")}
+        onClickUndo={action("onClickUndo")}
+        onClickRedo={action("onClickRedo")}
+        onClickPaste={action("onClickPaste")}
+      />
+    );
+  },
+};


### PR DESCRIPTION
## 制約

- `data-semantics`は結局付けていない
  - ContextMenuの修正が必要
  - 結局テストで使っていない、使うことが推奨されていない
- ContextMenuの開閉テストが行えていない
  - Storybookの`userEvent`でReact flowのバックグラウンドをクリックしても反応していない？